### PR TITLE
implement exponential-backoff retries for known server errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -801,6 +801,11 @@
         "strip-final-newline": "^2.0.0"
       }
     },
+    "exponential-backoff": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.0.tgz",
+      "integrity": "sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.27.2",
     "cli-progress": "^3.11.2",
     "dotenv": "^16.0.1",
+    "exponential-backoff": "^3.1.0",
     "mongodb": "^4.9.0",
     "node-emoji": "^1.11.0",
     "node-schedule": "^2.1.0",


### PR DESCRIPTION
En `utils/error.js` vi que hay algunos errores identificados que el servidor de Smiles puede devolver cada tanto. Si el error es uno de ellos que indican que el servidor pudiera estar caido temporalmente, este PR implementa [exponential-backoff retries](https://cloud.google.com/iot/docs/how-tos/exponential-backoff) para intentar eventualmente darle una respuesta al cliente. Si después de 10 intentos ninguno devuelve la info que buscamos, el request se asume como fallido y se le indica el error al cliente (tal como funciona actualmente, esta parte no se modificó).