### PR TITLE
retry on api error codes

### DIFF
--- a/clients/smilesClient.js
+++ b/clients/smilesClient.js
@@ -33,10 +33,11 @@ async function searchFlights(params) {
       const { data } = await smilesClient.get("/search", { params });
       return { data };
     } catch(error) {
+      const apiFailureRetryCodes = ['ETIMEDOUT', 'EAI_AGAIN', 'ECONNRESET'];
       const isFlightListUndefinedError = error.response?.data?.error === "TypeError: Cannot read property 'flightList' of undefined";
       const isServiceUnavailable = error.response?.data?.message === "Service Unavailable";
       // only attempt to backoff-retry requests matching any of the errors above, otherwise we will respond with the error straight to the client
-      const shouldRetryRequest = isFlightListUndefinedError || isServiceUnavailable;
+      const shouldRetryRequest = isFlightListUndefinedError || isServiceUnavailable || apiFailureRetryCodes.includes(error.code);
       if (shouldRetryRequest) throw error;
       return { error };
     }


### PR DESCRIPTION
@juanidambrosio agregué un par de error codes que suele tirar la API cuando falla por razones random que no tienen que ver con el input del usuario, esto debería ayudar a mejorar mucho el porcentaje de respuestas positivas si bien puede que demore más en responder por los retries. Idealmente pensaba luego agregar la posibilidad de editar el mensaje de Telegram con el número de reintentos que se está llevando a cabo para informar al usuario un poco de lo que está pasando.