### PR TITLE
Add inline buttons to quick search other months for single destinations

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -74,6 +74,27 @@ const tripTypes = {
   ONE_WAY: "2",
 };
 
+const monthSections = [
+  [
+    { name: "Enero", number: "01" },
+    { name: "Febrero", number: "02" },
+    { name: "Marzo", number: "03" },
+    { name: "Abril", number: "04" },
+  ],
+  [
+    { name: "Mayo", number: "05" },
+    { name: "Junio", number: "06" },
+    { name: "Julio", number: "07" },
+    { name: "Agosto", number: "08" },
+  ],
+  [
+    { name: "Septiembre", number: "09" },
+    { name: "Octubre", number: "10" },
+    { name: "Noviembre", number: "11" },
+    { name: "Diciembre", number: "12" },
+  ],
+];
+
 module.exports = {
   badResponse,
   dailyTweet,
@@ -101,4 +122,5 @@ module.exports = {
   airlinesCodes,
   maxAirports,
   tripTypes,
+  monthSections,
 };

--- a/telegram/alerts.js
+++ b/telegram/alerts.js
@@ -45,15 +45,13 @@ const checkDailyAlerts = async (bot) => {
 
 const checkPromoFlight = async (text, retries = 0) => {
   try {
-    const { bestFlight, response } = await searchCityQuery(
-      {
-        from,
-        chat,
-        text: text.journeyComplete,
-        promoMiles: text.promoMiles,
-      },
-      true
-    );
+    const { bestFlight, response } = await searchCityQuery({
+      from,
+      chat,
+      text: text.journeyComplete,
+      promoMiles: text.promoMiles,
+      isAlert: true,
+    });
 
     if (bestFlight && bestFlight.price <= text.promoMiles) {
       const journeyCompleteAlert = journeyAlerts.get(text.journey);

--- a/telegram/search.js
+++ b/telegram/search.js
@@ -9,6 +9,7 @@ const {
   generateEmissionLink,
   generateFlightOutput,
   generateEmissionLinkRoundTrip,
+  generatePayloadMonthlySingleDestinationAlerts,
 } = require("../utils/parser");
 
 const {
@@ -26,7 +27,9 @@ const { buildError } = require("../utils/error");
 const { getDbFunctions } = require("../db/dbFunctions");
 
 const searchCityQuery = async (msg, match) => {
-  const payload = generatePayloadMonthlySingleDestination(match);
+  const payload = match
+    ? generatePayloadMonthlySingleDestination(match)
+    : generatePayloadMonthlySingleDestinationAlerts(msg.text);
   const { createOne, getOne } = getDbFunctions();
   payload.preferences =
     (await getPreferencesDb(

--- a/telegram/search.js
+++ b/telegram/search.js
@@ -25,8 +25,8 @@ const { buildError } = require("../utils/error");
 
 const { getDbFunctions } = require("../db/dbFunctions");
 
-const searchCityQuery = async (msg, isAlert) => {
-  const payload = generatePayloadMonthlySingleDestination(msg.text);
+const searchCityQuery = async (msg, match) => {
+  const payload = generatePayloadMonthlySingleDestination(match);
   const { createOne, getOne } = getDbFunctions();
   payload.preferences =
     (await getPreferencesDb(
@@ -49,35 +49,36 @@ const searchCityQuery = async (msg, isAlert) => {
       msg.promoMiles && current.price > msg.promoMiles
         ? previous
         : previous.concat(
-          emoji.get("airplane") +
-          applySimpleMarkdown(
-            current.departureDay + "/" + flightList.departureMonth,
-            "[",
-            "]"
-          ) +
-          applySimpleMarkdown(
-            generateEmissionLink({
-              ...payload,
-              departureDate:
-                payload.departureDate + "-" + current.departureDay + " 09:",
-              tripType: tripTypes.ONE_WAY,
-            }),
-            "(",
-            ")"
-          ) +
-          ": " +
-          applySimpleMarkdown(
-            `${current.price.toString()} + ${current.money ? "$" + current.money.toString() + " + " : ""
-            }${current.tax.miles}/${current.tax.money}`,
-            "*"
-          ) +
-          generateFlightOutput(current) +
-          "\n"
-        ),
-    payload.origin + " " + payload.destination + " " + payload.departureDate + "\n"
+            emoji.get("airplane") +
+              applySimpleMarkdown(
+                current.departureDay + "/" + flightList.departureMonth,
+                "[",
+                "]"
+              ) +
+              applySimpleMarkdown(
+                generateEmissionLink({
+                  ...payload,
+                  departureDate:
+                    payload.departureDate + "-" + current.departureDay + " 09:",
+                  tripType: tripTypes.ONE_WAY,
+                }),
+                "(",
+                ")"
+              ) +
+              ": " +
+              applySimpleMarkdown(
+                `${current.price.toString()} + ${
+                  current.money ? "$" + current.money.toString() + " + " : ""
+                }${current.tax.miles}/${current.tax.money}`,
+                "*"
+              ) +
+              generateFlightOutput(current) +
+              "\n"
+          ),
+    payload.origin + " " + payload.destination + "\n"
   );
 
-  if (!isAlert) {
+  if (!msg.isAlert) {
     await createFlightSearch(
       {
         id: msg.from.username || msg.from.id.toString(),
@@ -107,7 +108,11 @@ const searchRegionalQuery = async (msg, fixedDay, isMultipleOrigin) => {
 
   const payload = isMultipleOrigin
     ? generatePayloadMultipleOrigins(msg.text, fixedDay, preferences.regions)
-    : generatePayloadMultipleDestinations(msg.text, fixedDay, preferences.regions);
+    : generatePayloadMultipleDestinations(
+        msg.text,
+        fixedDay,
+        preferences.regions
+      );
 
   payload.preferences = preferences;
 
@@ -124,7 +129,7 @@ const searchRegionalQuery = async (msg, fixedDay, isMultipleOrigin) => {
     }
 
     if (bestFlights.length === 0) {
-      return { error: notFound }
+      return { error: notFound };
     }
 
     const flightTitle = isMultipleOrigin
@@ -135,43 +140,44 @@ const searchRegionalQuery = async (msg, fixedDay, isMultipleOrigin) => {
       const dateToShow = fixedDay
         ? ""
         : " " +
-        current.departureDay +
-        "/" +
-        payload.departureDate.substring(5, 7);
+          current.departureDay +
+          "/" +
+          payload.departureDate.substring(5, 7);
       return previous.concat(
         emoji.get("airplane") +
-        applySimpleMarkdown(
-          (isMultipleOrigin ? current.origin : current.destination) +
-          dateToShow,
-          "[",
-          "]"
-        ) +
-        applySimpleMarkdown(
-          generateEmissionLink({
-            ...payload,
-            origin: isMultipleOrigin ? current.origin : payload.origin,
-            destination: isMultipleOrigin
-              ? payload.destination
-              : current.destination,
-            departureDate: fixedDay
-              ? payload.departureDate
-              : payload.departureDate.substring(0, 7) +
-              "-" +
-              current.departureDay +
-              " 09:",
-            tripType: tripTypes.ONE_WAY,
-          }),
-          "(",
-          ")"
-        ) +
-        ": " +
-        applySimpleMarkdown(
-          `${current.price.toString()} + ${current.money ? "$" + current.money.toString() + " + " : ""
-          }${current.tax.miles}/${current.tax.money}`,
-          "*"
-        ) +
-        generateFlightOutput(current) +
-        "\n"
+          applySimpleMarkdown(
+            (isMultipleOrigin ? current.origin : current.destination) +
+              dateToShow,
+            "[",
+            "]"
+          ) +
+          applySimpleMarkdown(
+            generateEmissionLink({
+              ...payload,
+              origin: isMultipleOrigin ? current.origin : payload.origin,
+              destination: isMultipleOrigin
+                ? payload.destination
+                : current.destination,
+              departureDate: fixedDay
+                ? payload.departureDate
+                : payload.departureDate.substring(0, 7) +
+                  "-" +
+                  current.departureDay +
+                  " 09:",
+              tripType: tripTypes.ONE_WAY,
+            }),
+            "(",
+            ")"
+          ) +
+          ": " +
+          applySimpleMarkdown(
+            `${current.price.toString()} + ${
+              current.money ? "$" + current.money.toString() + " + " : ""
+            }${current.tax.miles}/${current.tax.money}`,
+            "*"
+          ) +
+          generateFlightOutput(current) +
+          "\n"
       );
     }, flightTitle);
     await createFlightSearch(
@@ -189,9 +195,9 @@ const searchRegionalQuery = async (msg, fixedDay, isMultipleOrigin) => {
       createOne
     );
     console.log(msg.text);
-    return { response }
+    return { response };
   } catch (error) {
-    return { error: genericError }
+    return { error: genericError };
   }
 };
 
@@ -220,51 +226,53 @@ const searchRoundTrip = async (msg) => {
       (previous, current) =>
         previous.concat(
           emoji.get("airplane") +
-          applySimpleMarkdown(
-            current.departureFlight.departureDay.getDate() +
-            "/" +
-            (current.departureFlight.departureDay.getMonth() + 1) +
-            " - " +
-            current.returnFlight.departureDay.getDate() +
-            "/" +
-            (current.returnFlight.departureDay.getMonth() + 1),
-            "[",
-            "]"
-          ) +
-          applySimpleMarkdown(
-            generateEmissionLinkRoundTrip({
-              ...payload,
-              departureDate: current.departureFlight.departureDay.setHours(9),
-              returnDate: current.returnFlight.departureDay.setHours(9),
-              tripType: tripTypes.RETURN,
-            }),
-            "(",
-            ")"
-          ) +
-          ": " +
-          applySimpleMarkdown(
-            `${current.departureFlight.price.toString()} + ${current.departureFlight.money
-              ? "$" + current.departureFlight.money.toString() + " + "
-              : ""
-            }${current.returnFlight.price.toString()} + ${current.returnFlight.money
-              ? "$" + current.returnFlight.money.toString() + " + "
-              : ""
-            }${Math.floor(
-              (current.departureFlight.tax.milesNumber +
-                current.returnFlight.tax.milesNumber) /
-              1000
-            ).toString()}K/$${Math.floor(
-              (current.departureFlight.tax.moneyNumber +
-                current.returnFlight.tax.moneyNumber) /
-              1000
-            ).toString()}K`,
-            "*"
-          ) +
-          "\n IDA:" +
-          generateFlightOutput(current.departureFlight) +
-          "\n VUELTA:" +
-          generateFlightOutput(current.returnFlight) +
-          "\n"
+            applySimpleMarkdown(
+              current.departureFlight.departureDay.getDate() +
+                "/" +
+                (current.departureFlight.departureDay.getMonth() + 1) +
+                " - " +
+                current.returnFlight.departureDay.getDate() +
+                "/" +
+                (current.returnFlight.departureDay.getMonth() + 1),
+              "[",
+              "]"
+            ) +
+            applySimpleMarkdown(
+              generateEmissionLinkRoundTrip({
+                ...payload,
+                departureDate: current.departureFlight.departureDay.setHours(9),
+                returnDate: current.returnFlight.departureDay.setHours(9),
+                tripType: tripTypes.RETURN,
+              }),
+              "(",
+              ")"
+            ) +
+            ": " +
+            applySimpleMarkdown(
+              `${current.departureFlight.price.toString()} + ${
+                current.departureFlight.money
+                  ? "$" + current.departureFlight.money.toString() + " + "
+                  : ""
+              }${current.returnFlight.price.toString()} + ${
+                current.returnFlight.money
+                  ? "$" + current.returnFlight.money.toString() + " + "
+                  : ""
+              }${Math.floor(
+                (current.departureFlight.tax.milesNumber +
+                  current.returnFlight.tax.milesNumber) /
+                  1000
+              ).toString()}K/$${Math.floor(
+                (current.departureFlight.tax.moneyNumber +
+                  current.returnFlight.tax.moneyNumber) /
+                  1000
+              ).toString()}K`,
+              "*"
+            ) +
+            "\n IDA:" +
+            generateFlightOutput(current.departureFlight) +
+            "\n VUELTA:" +
+            generateFlightOutput(current.returnFlight) +
+            "\n"
         ),
       payload.origin + " " + payload.destination + "\n"
     );

--- a/telegram/telegramBot.js
+++ b/telegram/telegramBot.js
@@ -6,7 +6,8 @@ const {
   links,
   airlinesCodes,
   searching,
-  maxAirports
+  maxAirports,
+  monthSections,
 } = require("../config/constants");
 const regions = require("../data/regions");
 const { applySimpleMarkdown } = require("../utils/parser");
@@ -19,7 +20,7 @@ const {
   regexMultipleOriginFixedDay,
   regexRoundTrip,
   regexFilters,
-  regexCustomRegion
+  regexCustomRegion,
 } = require("../utils/regex");
 
 const { checkDailyAlerts } = require("./alerts");
@@ -52,7 +53,7 @@ const listen = async () => {
   );
 
   bot.onText(/\/regiones/, async (msg) => {
-    const entries = { ...regions, ...await getRegions(msg) };
+    const entries = { ...regions, ...(await getRegions(msg)) };
     const airports = Object.entries(entries).reduce(
       (phrase, current) =>
         phrase.concat(
@@ -75,81 +76,78 @@ const listen = async () => {
     bot.sendMessage(msg.chat.id, airlinesCodes, { parse_mode: "MarkdownV2" })
   );
 
-  bot.onText(regexSingleCities, async (msg) => {
+  bot.onText(regexSingleCities, async (msg, match) => {
     try {
+      const [origin, destination, departureMonth] = match.slice(1, 4);
+      console.log(origin + destination + departureMonth);
       bot.sendMessage(msg.chat.id, searching);
-      const { response } = await searchCityQuery(msg);
+      const { response } = await searchCityQuery(msg, match);
       console.log(msg.text);
-      bot.sendMessage(msg.chat.id, response, { parse_mode: "Markdown" });
+      const inlineKeyboardMonths = monthSections.map((monthSection) =>
+        monthSection.map((month) => ({
+          text: month.name,
+          callback_data: `${origin} ${destination} ${departureDate}`,
+        }))
+      );
+      bot.sendMessage(msg.chat.id, response, {
+        parse_mode: "Markdown",
+        reply_markup: {
+          inline_keyboard: inlineKeyboardMonths,
+        },
+      });
     } catch (error) {
       console.log(error.message);
       bot.sendMessage(msg.chat.id, buildError(error.message));
     }
   });
 
-  bot.onText(
-    regexMultipleDestinationMonthly,
-    async (msg) => {
-      const chatId = msg.chat.id;
-      bot.sendMessage(chatId, searching);
-      const { response, error } = await searchRegionalQuery(msg, false, false);
+  bot.onText(regexMultipleDestinationMonthly, async (msg) => {
+    const chatId = msg.chat.id;
+    bot.sendMessage(chatId, searching);
+    const { response, error } = await searchRegionalQuery(msg, false, false);
 
-      if (error) {
-        bot.sendMessage(chatId, error);
-      }
-      else {
-        bot.sendMessage(chatId, response, { parse_mode: "Markdown" })
-      }
+    if (error) {
+      bot.sendMessage(chatId, error);
+    } else {
+      bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
-  );
+  });
 
-  bot.onText(
-    regexMultipleDestinationFixedDay,
-    async (msg) => {
-      const chatId = msg.chat.id;
-      bot.sendMessage(chatId, searching);
-      const { response, error } = await searchRegionalQuery(msg, true, false);
+  bot.onText(regexMultipleDestinationFixedDay, async (msg) => {
+    const chatId = msg.chat.id;
+    bot.sendMessage(chatId, searching);
+    const { response, error } = await searchRegionalQuery(msg, true, false);
 
-      if (error) {
-        bot.sendMessage(chatId, error);
-      }
-      else {
-        bot.sendMessage(chatId, response, { parse_mode: "Markdown" })
-      }
+    if (error) {
+      bot.sendMessage(chatId, error);
+    } else {
+      bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
-  );
+  });
 
-  bot.onText(
-    regexMultipleOriginMonthly,
-    async (msg) => {
-      const chatId = msg.chat.id;
-      bot.sendMessage(chatId, searching);
-      const { response, error } = await searchRegionalQuery(msg, false, true);
+  bot.onText(regexMultipleOriginMonthly, async (msg) => {
+    const chatId = msg.chat.id;
+    bot.sendMessage(chatId, searching);
+    const { response, error } = await searchRegionalQuery(msg, false, true);
 
-      if (error) {
-        bot.sendMessage(chatId, error);
-      }
-      else {
-        bot.sendMessage(chatId, response, { parse_mode: "Markdown" })
-      }
+    if (error) {
+      bot.sendMessage(chatId, error);
+    } else {
+      bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
-  );
+  });
 
-  bot.onText(
-    regexMultipleOriginFixedDay,
-    async (msg) => {
-      const chatId = msg.chat.id;
-      bot.sendMessage(chatId, searching);
-      const { response, error } = await searchRegionalQuery(msg, true, true);
+  bot.onText(regexMultipleOriginFixedDay, async (msg) => {
+    const chatId = msg.chat.id;
+    bot.sendMessage(chatId, searching);
+    const { response, error } = await searchRegionalQuery(msg, true, true);
 
-      if (error) {
-        bot.sendMessage(chatId, error);
-      }
-      else {
-        bot.sendMessage(chatId, response, { parse_mode: "Markdown" })
-      }
+    if (error) {
+      bot.sendMessage(chatId, error);
+    } else {
+      bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
-  );
+  });
 
   bot.onText(regexRoundTrip, async (msg) => {
     const chatId = msg.chat.id;
@@ -157,19 +155,28 @@ const listen = async () => {
     const { response, error } = await searchRoundTrip(msg);
     if (error) {
       bot.sendMessage(chatId, error);
+    } else {
+      bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
-    else {
-      bot.sendMessage(chatId, response, { parse_mode: "Markdown" })
-    }
-  })
+  });
+
+  bot.on("callback_query", (query) => {
+    const action = query.data;
+    const opts = {
+      chatId: msg.chat.id,
+    };
+    bot.sendMessage(
+      opts.chatId,
+      `Finished callback with action ${action} and msg ${msg.text}`
+    );
+  });
 
   bot.onText(regexFilters, async (msg) => {
     const chatId = msg.chat.id;
     const { response, error } = await setPreferences(msg);
     if (error) {
       bot.sendMessage(chatId, error);
-    }
-    else {
+    } else {
       bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
   });
@@ -177,12 +184,18 @@ const listen = async () => {
   bot.onText(regexCustomRegion, async (msg, match) => {
     const chatId = msg.chat.id;
     const regionName = match[1].toUpperCase();
-    const regionAirports = match[2].split(" ").slice(0, maxAirports).map(airport => airport.toUpperCase());
-    const { response, error } = await setRegion(msg.from.username || msg.from.id.toString(), regionName, regionAirports);
+    const regionAirports = match[2]
+      .split(" ")
+      .slice(0, maxAirports)
+      .map((airport) => airport.toUpperCase());
+    const { response, error } = await setRegion(
+      msg.from.username || msg.from.id.toString(),
+      regionName,
+      regionAirports
+    );
     if (error) {
       bot.sendMessage(chatId, error);
-    }
-    else {
+    } else {
       bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
   });
@@ -192,8 +205,7 @@ const listen = async () => {
     const { response, error } = await deletePreferences(msg);
     if (error) {
       bot.sendMessage(chatId, error);
-    }
-    else {
+    } else {
       bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
   });
@@ -203,8 +215,7 @@ const listen = async () => {
     const { response, error } = await getPreferences(msg);
     if (error) {
       bot.sendMessage(chatId, error);
-    }
-    else {
+    } else {
       bot.sendMessage(chatId, response, { parse_mode: "Markdown" });
     }
   });

--- a/telegram/telegramBot.js
+++ b/telegram/telegramBot.js
@@ -78,7 +78,8 @@ const listen = async () => {
 
   bot.onText(regexSingleCities, async (msg, match) => {
     try {
-      const [origin, destination, departureMonth] = match.slice(1, 4);
+      const [origin, destination, departureMonth, parameter1, parameter2] =
+        match.slice(1, 6);
       console.log(origin + destination + departureMonth);
       bot.sendMessage(msg.chat.id, searching);
       const { response } = await searchCityQuery(msg, match);
@@ -86,7 +87,7 @@ const listen = async () => {
       const inlineKeyboardMonths = monthSections.map((monthSection) =>
         monthSection.map((month) => ({
           text: month.name,
-          callback_data: `${origin} ${destination} ${departureDate}`,
+          callback_data: `${origin} ${destination} ${departureMonth} ${parameter1} ${parameter2}`,
         }))
       );
       bot.sendMessage(msg.chat.id, response, {
@@ -162,13 +163,8 @@ const listen = async () => {
 
   bot.on("callback_query", (query) => {
     const action = query.data;
-    const opts = {
-      chatId: msg.chat.id,
-    };
-    bot.sendMessage(
-      opts.chatId,
-      `Finished callback with action ${action} and msg ${msg.text}`
-    );
+    const chatId = query.message.chat.id;
+    bot.sendMessage(chatId, `Finished callback with action ${action}`);
   });
 
   bot.onText(regexFilters, async (msg) => {

--- a/telegram/telegramBot.js
+++ b/telegram/telegramBot.js
@@ -42,6 +42,7 @@ const {
 const { buildError } = require("../utils/error");
 
 const { initializeDbFunctions } = require("../db/dbFunctions");
+const { padMonth } = require("../utils/string");
 
 const listen = async () => {
   const bot = new TelegramBot(telegramApiToken, { polling: true });
@@ -80,15 +81,17 @@ const listen = async () => {
     try {
       const [origin, destination, departureMonth, parameter1, parameter2] =
         match.slice(1, 6);
-      console.log(origin + destination + departureMonth);
       bot.sendMessage(msg.chat.id, searching);
       const { response } = await searchCityQuery(msg, match);
       console.log(msg.text);
-      const inlineKeyboardMonths = monthSections.map((monthSection) =>
-        monthSection.map((month) => ({
-          text: month.name,
-          callback_data: `${origin} ${destination} ${departureMonth} ${parameter1} ${parameter2}`,
-        }))
+      const inlineKeyboardMonths = monthSections.map(
+        (monthSection, indexSection) =>
+          monthSection.map((month, indexMonth) => ({
+            text: month.name,
+            callback_data: `${origin} ${destination} ${padMonth(
+              monthSection.length * indexSection + (indexMonth + 1)
+            )} ${parameter1 || ""} ${parameter2 || ""}`.trimEnd(),
+          }))
       );
       bot.sendMessage(msg.chat.id, response, {
         parse_mode: "Markdown",

--- a/telegram/telegramBotHandler.js
+++ b/telegram/telegramBotHandler.js
@@ -1,0 +1,34 @@
+const { monthSections, searching } = require("../config/constants");
+const { buildError } = require("../utils/error");
+const { padMonth } = require("../utils/string");
+const { searchCityQuery } = require("./search");
+
+const searchSingleDestination = async (match, msg, bot) => {
+  bot.sendMessage(msg.chat.id, searching);
+  try {
+    const [origin, destination, departureMonth, parameter1, parameter2] =
+      match.slice(1, 6);
+    const { response } = await searchCityQuery(msg, match);
+    console.log(match[0]);
+    const inlineKeyboardMonths = monthSections.map(
+      (monthSection, indexSection) =>
+        monthSection.map((month, indexMonth) => ({
+          text: month.name,
+          callback_data: `${origin} ${destination} ${padMonth(
+            monthSection.length * indexSection + (indexMonth + 1)
+          )} ${parameter1 || ""} ${parameter2 || ""}`.trimEnd(),
+        }))
+    );
+    bot.sendMessage(msg.chat.id, response, {
+      parse_mode: "Markdown",
+      reply_markup: {
+        inline_keyboard: inlineKeyboardMonths,
+      },
+    });
+  } catch (error) {
+    console.log(error.message);
+    bot.sendMessage(msg.chat.id, buildError(error.message));
+  }
+};
+
+module.exports = { searchSingleDestination };

--- a/tests/utils/parser.spec.js
+++ b/tests/utils/parser.spec.js
@@ -7,24 +7,24 @@ const {
   belongsToCity,
   generateEmissionLink,
   generateEmissionLinkRoundTrip,
-} = require('../../utils/parser');
-const regions = require('../../data/regions');
-const { tripTypes } = require('../../config/constants');
+} = require("../../utils/parser");
+const regions = require("../../data/regions");
+const { tripTypes } = require("../../config/constants");
 
-jest.mock('../../config/constants', () => ({
-  ...jest.requireActual('../../config/constants'),
-  SMILES_EMISSION_URL: 'smilesUrl/',
+jest.mock("../../config/constants", () => ({
+  ...jest.requireActual("../../config/constants"),
+  SMILES_EMISSION_URL: "smilesUrl/",
 }));
-describe('parser', () => {
-  describe('generateEmissionLink', () => {
-    it('should return correct emission link', () => {
-      const mockedDepartureDate = '2023-03-03';
+describe("parser", () => {
+  describe("generateEmissionLink", () => {
+    it("should return correct emission link", () => {
+      const mockedDepartureDate = "2023-03-03";
       expect(
         generateEmissionLink({
-          origin: 'EZE',
-          destination: 'LHR',
+          origin: "EZE",
+          destination: "LHR",
           adults: 3,
-          cabinType: 'EJE',
+          cabinType: "EJE",
           tripType: tripTypes.ONE_WAY,
           departureDate: mockedDepartureDate,
         })
@@ -38,16 +38,16 @@ describe('parser', () => {
     });
   });
 
-  describe('generateEmissionLinkRoundTrip', () => {
-    it('should return correct emission link', () => {
-      const mockedDepartureDate = '2023-03-03';
-      const mockedReturnDate = new Date('2023-03-21').getTime();
+  describe("generateEmissionLinkRoundTrip", () => {
+    it("should return correct emission link", () => {
+      const mockedDepartureDate = "2023-03-03";
+      const mockedReturnDate = new Date("2023-03-21").getTime();
       expect(
         generateEmissionLinkRoundTrip({
-          origin: 'EZE',
-          destination: 'LHR',
+          origin: "EZE",
+          destination: "LHR",
           adults: 3,
-          cabinType: 'EJE',
+          cabinType: "EJE",
           tripType: tripTypes.ONE_WAY,
           departureDate: mockedDepartureDate,
           returnDate: mockedReturnDate,
@@ -61,223 +61,235 @@ describe('parser', () => {
       );
     });
   });
-  describe('belongsToCity', () => {
+  describe("belongsToCity", () => {
     it.each([
-      ['EZE', 'BUE'],
-      ['AEP', 'BUE'],
-      ['GIG', 'RIO'],
-      ['SDU', 'RIO'],
-      ['CFB', 'RIO'],
-      ['LHR', 'LON'],
-      ['LGW', 'LON'],
-      ['LCY', 'LON'],
-      ['STN', 'LON'],
-      ['FCO', 'ROM'],
-      ['GRU', 'SAO'],
-      ['CGH', 'SAO'],
-      ['CDG', 'PAR'],
-      ['ORY', 'PAR'],
-    ])('should return true when %s belongs to city %s', (airport, city) => {
+      ["EZE", "BUE"],
+      ["AEP", "BUE"],
+      ["GIG", "RIO"],
+      ["SDU", "RIO"],
+      ["CFB", "RIO"],
+      ["LHR", "LON"],
+      ["LGW", "LON"],
+      ["LCY", "LON"],
+      ["STN", "LON"],
+      ["FCO", "ROM"],
+      ["GRU", "SAO"],
+      ["CGH", "SAO"],
+      ["CDG", "PAR"],
+      ["ORY", "PAR"],
+    ])("should return true when %s belongs to city %s", (airport, city) => {
       expect(belongsToCity(airport, city)).toBeTruthy();
     });
 
-    it('should return true when airport belongs to city', () => {
-      expect(belongsToCity('LHR', 'BUE')).toBeFalsy();
+    it("should return true when airport belongs to city", () => {
+      expect(belongsToCity("LHR", "BUE")).toBeFalsy();
     });
   });
-  describe('generatePayloadMonthlySingleDestination', () => {
-    it('should generate payload for using a single destination', () => {
+  describe("generatePayloadMonthlySingleDestination", () => {
+    it("should generate payload for using a single destination", () => {
       expect(
-        generatePayloadMonthlySingleDestination(`EZE MAD 2023-05`)
+        generatePayloadMonthlySingleDestination([
+          "EZE MAD 2023-05",
+          "EZE",
+          "MAD",
+          "05",
+        ])
       ).toEqual({
-        destination: 'MAD',
-        origin: 'EZE',
-        departureDate: '2023-05',
-        adults: '',
-        cabinType: '',
+        destination: "MAD",
+        origin: "EZE",
+        departureDate: "2023-05",
+        adults: "",
+        cabinType: "",
       });
     });
 
-    it('should generate payload for using a single destination adults and cabin types', () => {
+    it("should generate payload for using a single destination adults and cabin types", () => {
       expect(
-        generatePayloadMonthlySingleDestination(`EZE MAD 2023-05 3 EJE`)
+        generatePayloadMonthlySingleDestination([
+          "EZE MAD 2023-05",
+          "EZE",
+          "MAD",
+          "05",
+          "3",
+          "EJE"
+        ])
       ).toEqual({
-        destination: 'MAD',
-        origin: 'EZE',
-        departureDate: '2023-05',
-        adults: '3',
-        cabinType: 'EJE',
+        destination: "MAD",
+        origin: "EZE",
+        departureDate: "2023-05",
+        adults: "3",
+        cabinType: "EJE",
       });
     });
   });
-  describe('generatePayloadMultipleDestinations', () => {
-    it('should generate payload when using a region (multiple destinations)', () => {
-      const mockedRegion = 'EUROPA';
+  describe("generatePayloadMultipleDestinations", () => {
+    it("should generate payload when using a region (multiple destinations)", () => {
+      const mockedRegion = "EUROPA";
       const result = generatePayloadMultipleDestinations(
         `EZE ${mockedRegion} 2023-05`
       );
 
       expect(result).toEqual({
-        destination: regions['EUROPA'],
-        origin: 'EZE',
-        departureDate: '2023-05',
-        adults: '',
-        cabinType: '',
+        destination: regions["EUROPA"],
+        origin: "EZE",
+        departureDate: "2023-05",
+        adults: "",
+        cabinType: "",
         region: mockedRegion,
       });
     });
 
-    it('should generate payload when using a region, cabinType and amount of adults', () => {
-      const mockedRegion = 'EUROPA';
+    it("should generate payload when using a region, cabinType and amount of adults", () => {
+      const mockedRegion = "EUROPA";
       const result = generatePayloadMultipleDestinations(
         `EZE ${mockedRegion} 2023-05 EJE 3`
       );
 
       expect(result).toEqual({
-        destination: regions['EUROPA'],
-        origin: 'EZE',
-        departureDate: '2023-05',
-        adults: '3',
-        cabinType: 'EJE',
+        destination: regions["EUROPA"],
+        origin: "EZE",
+        departureDate: "2023-05",
+        adults: "3",
+        cabinType: "EJE",
         region: mockedRegion,
       });
     });
   });
-  describe('generatePayloadMultipleOrigins', () => {
-    it('should generate payload when using a region (multiple origin)', () => {
-      const mockedRegion = 'EUROPA';
+  describe("generatePayloadMultipleOrigins", () => {
+    it("should generate payload when using a region (multiple origin)", () => {
+      const mockedRegion = "EUROPA";
       const result = generatePayloadMultipleOrigins(
         `${mockedRegion} EZE 2023-05`
       );
 
       expect(result).toEqual({
-        origin: regions['EUROPA'],
-        destination: 'EZE',
-        departureDate: '2023-05',
-        adults: '',
-        cabinType: '',
+        origin: regions["EUROPA"],
+        destination: "EZE",
+        departureDate: "2023-05",
+        adults: "",
+        cabinType: "",
         region: mockedRegion,
       });
     });
 
-    it('should generate payload when using a region, cabinType and amount of adults', () => {
-      const mockedRegion = 'EUROPA';
+    it("should generate payload when using a region, cabinType and amount of adults", () => {
+      const mockedRegion = "EUROPA";
       const result = generatePayloadMultipleOrigins(
         `${mockedRegion} EZE 2023-05 EJE 3`
       );
 
       expect(result).toEqual({
-        origin: regions['EUROPA'],
-        destination: 'EZE',
-        departureDate: '2023-05',
-        adults: '3',
-        cabinType: 'EJE',
+        origin: regions["EUROPA"],
+        destination: "EZE",
+        departureDate: "2023-05",
+        adults: "3",
+        cabinType: "EJE",
         region: mockedRegion,
       });
     });
   });
-  describe('generatePayloadRoundTrip', () => {
-    it('should generate round trip basic payload with min', () => {
+  describe("generatePayloadRoundTrip", () => {
+    it("should generate round trip basic payload with min", () => {
       const result = generatePayloadRoundTrip(
         `EZE BCN 2023-03-01 2023-03-30 m7`
       );
 
       expect(result).toEqual({
-        origin: 'EZE',
-        destination: 'BCN',
-        departureDate: '2023-03-01',
-        returnDate: '2023-03-30',
-        adultsGoing: '',
-        cabinTypeGoing: '',
-        adultsComing: '',
-        cabinTypeComing: '',
+        origin: "EZE",
+        destination: "BCN",
+        departureDate: "2023-03-01",
+        returnDate: "2023-03-30",
+        adultsGoing: "",
+        cabinTypeGoing: "",
+        adultsComing: "",
+        cabinTypeComing: "",
         maxDays: undefined,
         minDays: 7,
       });
     });
 
-    it('should generate round trip basic payload with min days and max days', () => {
+    it("should generate round trip basic payload with min days and max days", () => {
       const result = generatePayloadRoundTrip(
         `EZE BCN 2023-03-01 2023-03-30 m7 M14`
       );
 
       expect(result).toEqual({
-        origin: 'EZE',
-        destination: 'BCN',
-        departureDate: '2023-03-01',
-        returnDate: '2023-03-30',
-        adultsGoing: '',
-        cabinTypeGoing: '',
-        adultsComing: '',
-        cabinTypeComing: '',
+        origin: "EZE",
+        destination: "BCN",
+        departureDate: "2023-03-01",
+        returnDate: "2023-03-30",
+        adultsGoing: "",
+        cabinTypeGoing: "",
+        adultsComing: "",
+        cabinTypeComing: "",
         maxDays: 14,
         minDays: 7,
       });
     });
 
-    it('should generate round trip basic payload cabin types and amount of people', () => {
+    it("should generate round trip basic payload cabin types and amount of people", () => {
       const result = generatePayloadRoundTrip(
         `EZE BCN 2023-03-01 EJE 2 2023-03-30 m7 ECO 3`
       );
 
       expect(result).toEqual({
-        origin: 'EZE',
-        destination: 'BCN',
-        departureDate: '2023-03-01',
-        returnDate: '2023-03-30',
-        adultsGoing: '2',
-        cabinTypeGoing: 'EJE',
-        adultsComing: '3',
-        cabinTypeComing: 'ECO',
+        origin: "EZE",
+        destination: "BCN",
+        departureDate: "2023-03-01",
+        returnDate: "2023-03-30",
+        adultsGoing: "2",
+        cabinTypeGoing: "EJE",
+        adultsComing: "3",
+        cabinTypeComing: "ECO",
         maxDays: undefined,
         minDays: 7,
       });
     });
   });
-  describe('preferencesParse', () => {
-    it('should return empty object if no parameters detected on msg str', () => {
-      expect(preferencesParser('', {})).toEqual({});
+  describe("preferencesParse", () => {
+    it("should return empty object if no parameters detected on msg str", () => {
+      expect(preferencesParser("", {})).toEqual({});
     });
 
-    it('should parse stops preference', () => {
-      expect(preferencesParser('filtros e:3', {})).toEqual({ stops: '3' });
+    it("should parse stops preference", () => {
+      expect(preferencesParser("filtros e:3", {})).toEqual({ stops: "3" });
     });
 
-    it('should parse max results preference', () => {
-      expect(preferencesParser('filtros r:12', {})).toEqual({
-        maxresults: '12',
+    it("should parse max results preference", () => {
+      expect(preferencesParser("filtros r:12", {})).toEqual({
+        maxresults: "12",
       });
     });
 
-    it('should parse max hours preference', () => {
-      expect(preferencesParser('filtros h:12', {})).toEqual({ maxhours: '12' });
+    it("should parse max hours preference", () => {
+      expect(preferencesParser("filtros h:12", {})).toEqual({ maxhours: "12" });
     });
 
-    it('should parse brasilNonGol preference', () => {
-      expect(preferencesParser('filtros singol', {})).toEqual({
+    it("should parse brasilNonGol preference", () => {
+      expect(preferencesParser("filtros singol", {})).toEqual({
         brasilNonGol: true,
       });
     });
 
-    it('should parse viajefacil preference', () => {
-      expect(preferencesParser('filtros vf', { previousfare: false })).toEqual({
+    it("should parse viajefacil preference", () => {
+      expect(preferencesParser("filtros vf", { previousfare: false })).toEqual({
         fare: true,
       });
 
-      expect(preferencesParser('filtros vf', { previousfare: true })).toEqual({
+      expect(preferencesParser("filtros vf", { previousfare: true })).toEqual({
         fare: false,
       });
     });
 
-    it('should parse smilesandmoney preference', () => {
+    it("should parse smilesandmoney preference", () => {
       expect(
-        preferencesParser('filtros smilesandmoney', { previousfare: false })
+        preferencesParser("filtros smilesandmoney", { previousfare: false })
       ).toEqual({
         smilesAndMoney: true,
       });
 
       expect(
-        preferencesParser('filtros smilesandmoney', {
+        preferencesParser("filtros smilesandmoney", {
           previousSmilesAndMoney: true,
         })
       ).toEqual({
@@ -285,21 +297,21 @@ describe('parser', () => {
       });
     });
 
-    it('should parse airlines preference', () => {
-      expect(preferencesParser('filtros a:AM', {})).toEqual({
-        airlines: ['AM'],
+    it("should parse airlines preference", () => {
+      expect(preferencesParser("filtros a:AM", {})).toEqual({
+        airlines: ["AM"],
       });
 
-      expect(preferencesParser('filtros a:AM ET AT', {})).toEqual({
-        airlines: ['AM', 'ET', 'AT'],
+      expect(preferencesParser("filtros a:AM ET AT", {})).toEqual({
+        airlines: ["AM", "ET", "AT"],
       });
     });
 
-    it('should parse multiple preferences ', () => {
-      expect(preferencesParser('filtros a:AV ET e:1 r:30 vf', {})).toEqual({
-        airlines: ['AV', 'ET'],
-        stops: '1',
-        maxresults: '30',
+    it("should parse multiple preferences ", () => {
+      expect(preferencesParser("filtros a:AV ET e:1 r:30 vf", {})).toEqual({
+        airlines: ["AV", "ET"],
+        stops: "1",
+        maxresults: "30",
         fare: true,
       });
     });

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -19,13 +19,13 @@ const calculateIndex = (parameters, indexStart) => {
       case 5:
         return !isNaN(parameters[0])
           ? {
-            adults: indexStart,
-            cabinType: indexStart + 2,
-          }
+              adults: indexStart,
+              cabinType: indexStart + 2,
+            }
           : {
-            adults: indexStart + 4,
-            cabinType: indexStart,
-          };
+              adults: indexStart + 4,
+              cabinType: indexStart,
+            };
       case 3:
         return { cabinType: indexStart };
       case 1:
@@ -41,27 +41,30 @@ const generateFlightOutput = (flight) =>
     flight.airline,
     flight.stops + " escalas",
     emoji.get("clock1") +
-    flight.duration +
-    "hs," +
-    emoji.get("seat") +
-    flight.seats,
+      flight.duration +
+      "hs," +
+      emoji.get("seat") +
+      flight.seats,
   ];
 
 const mapCabinType = (cabinType) =>
   cabinType === "ECO"
     ? "ECONOMIC"
     : cabinType === "EJE"
-      ? "BUSINESS"
-      : cabinType === "PEC"
-        ? "PREMIUM_ECONOMIC"
-        : "all";
+    ? "BUSINESS"
+    : cabinType === "PEC"
+    ? "PREMIUM_ECONOMIC"
+    : "all";
 
 const generateEmissionLink = (flight) =>
-  `${SMILES_EMISSION_URL}originAirportCode=${flight.origin
+  `${SMILES_EMISSION_URL}originAirportCode=${
+    flight.origin
   }&destinationAirportCode=${flight.destination}&departureDate=${new Date(
     flight.departureDate
-  ).getTime()}&adults=${flight.adults || "1"
-  }&infants=0&children=0&cabinType=${mapCabinType(flight.cabinType)}&tripType=${flight.tripType
+  ).getTime()}&adults=${
+    flight.adults || "1"
+  }&infants=0&children=0&cabinType=${mapCabinType(flight.cabinType)}&tripType=${
+    flight.tripType
   }`;
 
 const generateEmissionLinkRoundTrip = (flight) =>
@@ -98,8 +101,8 @@ const belongsToCity = (airport, city) => {
 };
 
 const findMonthAndYearFromText = (text) => {
-  let [origin, destination, dateString] = text.split(' ');
-  if (dateString.includes('-')) return dateString;
+  let [origin, destination, dateString] = text.split(" ");
+  if (dateString.includes("-")) return dateString;
   const month = Number(dateString);
   let year = new Date().getFullYear();
   const currentMonth = new Date().getMonth() + 1;
@@ -107,23 +110,28 @@ const findMonthAndYearFromText = (text) => {
     year += 1;
   }
   return `${year}-${dateString}`;
-}
+};
 
-const generatePayloadMonthlySingleDestination = (text) => {
-  const departureDate = findMonthAndYearFromText(text);
-  const { adults, cabinType } = calculateIndex(text.substring(16), 16);
+const generatePayloadMonthlySingleDestination = (match) => {
+  const [origin, destination, departureMonth] = match.slice(1, 4);
+  const departureDate = findMonthAndYearFromText(match[0]);
+  const { adults, cabinType } = calculateIndex(match[0].substring(16), 16);
   return {
-    origin: text.substring(0, 3).toUpperCase(),
-    destination: text.substring(4, 7).toUpperCase(),
+    origin: match[0].substring(0, 3).toUpperCase(),
+    destination: match[0].substring(4, 7).toUpperCase(),
     departureDate,
-    adults: adults ? text.substring(adults, adults + 1) : "",
+    adults: adults ? match[0].substring(adults, adults + 1) : "",
     cabinType: cabinType
-      ? text.substring(cabinType, cabinType + 3).toUpperCase()
+      ? match[0].substring(cabinType, cabinType + 3).toUpperCase()
       : "",
   };
 };
 
-const generatePayloadMultipleDestinations = (text, fixedDay, customRegions = []) => {
+const generatePayloadMultipleDestinations = (
+  text,
+  fixedDay,
+  customRegions = []
+) => {
   const departureDate = findMonthAndYearFromText(text);
   const regionsCopy = getCustomRegions(customRegions);
   const offset = fixedDay ? 10 : 7;
@@ -167,7 +175,7 @@ const generatePayloadMultipleOrigins = (text, fixedDay, customRegions = {}) => {
       : "",
     region,
   };
-}
+};
 
 const getCustomRegions = (customRegions) => {
   let regionsCopy = undefined;
@@ -268,7 +276,9 @@ const preferencesParser = (text, booleanPreferences) => {
   }
 
   if (offsetCustomRegion > 0) {
-    const [name, airportsString] = text.substring(offsetCustomRegion).split("/");
+    const [name, airportsString] = text
+      .substring(offsetCustomRegion)
+      .split("/");
     const airports = airportsString.toUpperCase().split(" ");
     result.customRegions = { name, airports };
   }

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -35,6 +35,21 @@ const calculateIndex = (parameters, indexStart) => {
   return { adults: undefined, cabinType: undefined };
 };
 
+const getAdultsAndCabinType = (parameters) => {
+  const regex = /^\d$|^(EJE|ECO|PEC)$/;
+  const parametersToReturn = { adults: undefined, cabinType: undefined };
+  for (const parameter of parameters) {
+    if (regex.test(parameter?.toUpperCase())) {
+      if (parameter.length === 3) {
+        parametersToReturn.cabinType = parameter.toUpperCase();
+      } else if (parameter.length === 1) {
+        parametersToReturn.adults = parameter;
+      }
+    }
+  }
+  return parametersToReturn;
+};
+
 const generateFlightOutput = (flight) =>
   " " +
   [
@@ -113,17 +128,17 @@ const findMonthAndYearFromText = (text) => {
 };
 
 const generatePayloadMonthlySingleDestination = (match) => {
-  const [origin, destination, departureMonth] = match.slice(1, 4);
+  const [origin, destination, departureMonth, parameter1, parameter2] =
+    match.slice(1, 6);
+  //TODO: Update below function to receive month when changing all payload generations
   const departureDate = findMonthAndYearFromText(match[0]);
-  const { adults, cabinType } = calculateIndex(match[0].substring(16), 16);
+  const { adults, cabinType } = getAdultsAndCabinType([parameter1, parameter2]);
   return {
-    origin: match[0].substring(0, 3).toUpperCase(),
-    destination: match[0].substring(4, 7).toUpperCase(),
+    origin: origin.toUpperCase(),
+    destination: destination.toUpperCase(),
     departureDate,
-    adults: adults ? match[0].substring(adults, adults + 1) : "",
-    cabinType: cabinType
-      ? match[0].substring(cabinType, cabinType + 3).toUpperCase()
-      : "",
+    adults: adults || "",
+    cabinType: cabinType || "",
   };
 };
 

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -142,6 +142,19 @@ const generatePayloadMonthlySingleDestination = (match) => {
   };
 };
 
+const generatePayloadMonthlySingleDestinationAlerts = (text) => {
+  const { adults, cabinType } = calculateIndex(text.substring(16), 16);
+  return {
+    origin: text.substring(0, 3).toUpperCase(),
+    destination: text.substring(4, 7).toUpperCase(),
+    departureDate: text.substring(8, 15),
+    adults: adults ? text.substring(adults, adults + 1) : "",
+    cabinType: cabinType
+      ? text.substring(cabinType, cabinType + 3).toUpperCase()
+      : "",
+  };
+};
+
 const generatePayloadMultipleDestinations = (
   text,
   fixedDay,
@@ -335,6 +348,7 @@ module.exports = {
   partitionArrays,
   belongsToCity,
   generatePayloadMonthlySingleDestination,
+  generatePayloadMonthlySingleDestinationAlerts,
   generatePayloadMultipleDestinations,
   generatePayloadMultipleOrigins,
   generatePayloadRoundTrip,

--- a/utils/regex.js
+++ b/utils/regex.js
@@ -1,5 +1,5 @@
 const regexSingleCities =
-  /^\w{3}(\s|-)\w{3}\s(\d{4}[-|\/])?(0|1)\d(\s(\d|\w{3})){0,2}$/;
+  /(^\w{3})[\s-](\w{3})\s(?:\d{4}[-\/])?([01]\d)(?:\s(\d|\w{3}))?(?:\s(\d|\w{3}))?$/;
 const regexMultipleDestinationMonthly =
   /^\w{3}(\s|-)\w{4,}\s(\d{4}[-|\/])?[0-1]\d(\s(\d|\w{3})){0,2}$/;
 const regexMultipleDestinationFixedDay =


### PR DESCRIPTION
- Refactor single destination query parsing by using `match` parameter
- Add all 12 months buttons to quick search for same origin/destination
- Alerts still use old parsing method